### PR TITLE
Andy's EDK2 port

### DIFF
--- a/Andy-s-patches-for-GRUB.patch
+++ b/Andy-s-patches-for-GRUB.patch
@@ -1,0 +1,754 @@
+From 5252c85f054a3dbff3a349c179b7a75a6731044c Mon Sep 17 00:00:00 2001
+From: Andy Vandijck <andyvand@gmail.com>
+Date: Tue, 12 Aug 2014 20:02:07 +0200
+Subject: [PATCH] Andy's patches for GRUB
+
+---
+ grub-core/boot/decompressor/xz.c  |  1 +
+ grub-core/fs/hfsplus.c            | 23 +++++----------
+ grub-core/fs/hfspluscomp.c        | 19 +++++++------
+ grub-core/fs/ntfs.c               |  6 +---
+ grub-core/fs/ntfscomp.c           | 11 +++----
+ grub-core/fs/proc.c               | 24 +++++++++++++++-
+ grub-core/fs/reiserfs.c           |  2 ++
+ grub-core/fs/squash4.c            |  1 +
+ grub-core/io/gzio.c               |  4 +++
+ grub-core/io/xzio.c               |  1 +
+ grub-core/kern/err.c              |  1 -
+ grub-core/kern/misc.c             |  3 --
+ grub-core/lib/minilzo/lzoconf.h   | 21 ++++++++++++--
+ grub-core/lib/minilzo/lzodefs.h   | 11 +++----
+ grub-core/lib/minilzo/minilzo.c   | 60 +++++++++++++++------------------------
+ grub-core/lib/xzembed/xz.h        |  8 ++++--
+ grub-core/lib/xzembed/xz_config.h | 29 ++++++++++++-------
+ include/grub/efi/api.h            |  2 ++
+ include/grub/hfsplus.h            |  4 +--
+ include/grub/misc.h               | 13 ++++++++-
+ include/grub/ntfs.h               |  4 +--
+ 21 files changed, 141 insertions(+), 107 deletions(-)
+
+diff --git a/grub-core/boot/decompressor/xz.c b/grub-core/boot/decompressor/xz.c
+index 2279118..6071753 100644
+--- a/grub-core/boot/decompressor/xz.c
++++ b/grub-core/boot/decompressor/xz.c
+@@ -20,6 +20,7 @@
+ #include <grub/misc.h>
+ #include <grub/decompressor.h>
+ 
++#include "xz_config.h"
+ #include "xz.h"
+ #include "xz_stream.h"
+ 
+diff --git a/grub-core/fs/hfsplus.c b/grub-core/fs/hfsplus.c
+index 950d8a1..3887dd3 100644
+--- a/grub-core/fs/hfsplus.c
++++ b/grub-core/fs/hfsplus.c
+@@ -105,14 +105,6 @@ enum grub_hfsplus_filetype
+ 
+ static grub_dl_t my_mod;
+ 
+-
+-
+-grub_err_t (*grub_hfsplus_open_compressed) (struct grub_fshelp_node *node);
+-grub_ssize_t (*grub_hfsplus_read_compressed) (struct grub_hfsplus_file *node,
+-					      grub_off_t pos,
+-					      grub_size_t len,
+-					      char *buf);
+-
+ /* Find the extent that points to FILEBLOCK.  If it is not in one of
+    the 8 extents described by EXTENT, return -1.  In that case set
+    FILEBLOCK to the next block.  */
+@@ -832,13 +824,10 @@ grub_hfsplus_open (struct grub_file *file, const char *name)
+   if (grub_errno)
+     goto fail;
+ 
+-  if (grub_hfsplus_open_compressed)
+-    {
+-      grub_err_t err;
+-      err = grub_hfsplus_open_compressed (fdiro);
+-      if (err)
+-	goto fail;
+-    }
++  grub_err_t err;
++  err = grub_hfsplus_open_compressed (fdiro);
++  if (err)
++    goto fail;
+ 
+   file->size = fdiro->size;
+   data->opened_file = *fdiro;
+@@ -885,9 +874,11 @@ grub_hfsplus_read (grub_file_t file, char *buf, grub_size_t len)
+ 
+   data->opened_file.file = file;
+ 
+-  if (grub_hfsplus_read_compressed && data->opened_file.compressed)
++  if (data->opened_file.compressed)
++  {
+     return grub_hfsplus_read_compressed (&data->opened_file,
+ 					 file->offset, len, buf);
++  }
+ 
+   return grub_hfsplus_read_file (&data->opened_file,
+ 				 file->read_hook, file->read_hook_data,
+diff --git a/grub-core/fs/hfspluscomp.c b/grub-core/fs/hfspluscomp.c
+index d76f3f1..7b031d3 100644
+--- a/grub-core/fs/hfspluscomp.c
++++ b/grub-core/fs/hfspluscomp.c
+@@ -179,6 +179,13 @@ hfsplus_read_compressed_real (struct grub_hfsplus_file *node,
+   return len0;
+ }
+ 
++grub_ssize_t
++grub_hfsplus_read_compressed(struct grub_hfsplus_file *node,
++                             grub_off_t pos, grub_size_t len, char *buf)
++{
++    return hfsplus_read_compressed_real(node, pos, len, buf);
++}
++
+ static grub_err_t 
+ hfsplus_open_compressed_real (struct grub_hfsplus_file *node)
+ {
+@@ -304,14 +311,8 @@ hfsplus_open_compressed_real (struct grub_hfsplus_file *node)
+   return 0;
+ }
+ 
+-GRUB_MOD_INIT(hfspluscomp)
+-{
+-  grub_hfsplus_open_compressed = hfsplus_open_compressed_real;  
+-  grub_hfsplus_read_compressed = hfsplus_read_compressed_real;  
+-}
+-
+-GRUB_MOD_FINI(hfspluscomp)
++grub_err_t
++grub_hfsplus_open_compressed (struct grub_hfsplus_file *node)
+ {
+-  grub_hfsplus_open_compressed = 0;
+-  grub_hfsplus_read_compressed = 0;
++    return hfsplus_open_compressed_real (node);
+ }
+diff --git a/grub-core/fs/ntfs.c b/grub-core/fs/ntfs.c
+index d3a91f5..a934677 100644
+--- a/grub-core/fs/ntfs.c
++++ b/grub-core/fs/ntfs.c
+@@ -52,8 +52,6 @@ u64at (void *ptr, grub_size_t ofs)
+   return grub_le_to_cpu64 (grub_get_unaligned64 ((char *) ptr + ofs));
+ }
+ 
+-grub_ntfscomp_func_t grub_ntfscomp_func;
+-
+ static grub_err_t
+ fixup (grub_uint8_t *buf, grub_size_t len, const grub_uint8_t *magic)
+ {
+@@ -400,9 +398,7 @@ read_data (struct grub_ntfs_attr *at, grub_uint8_t *pa, grub_uint8_t *dest,
+       if (!cached)
+ 	return grub_error (GRUB_ERR_BAD_FS, "attribute can\'t be compressed");
+ 
+-      return (grub_ntfscomp_func) ? grub_ntfscomp_func (dest, ofs, len, ctx)
+-	: grub_error (GRUB_ERR_BAD_FS, N_("module `%s' isn't loaded"),
+-		      "ntfscomp");
++      return grub_ntfscomp_func (dest, ofs, len, ctx);
+     }
+ 
+   ctx->target_vcn = ofs >> (GRUB_NTFS_BLK_SHR + ctx->comp.log_spc);
+diff --git a/grub-core/fs/ntfscomp.c b/grub-core/fs/ntfscomp.c
+index 2e1ce51..1b0dfc6 100644
+--- a/grub-core/fs/ntfscomp.c
++++ b/grub-core/fs/ntfscomp.c
+@@ -432,12 +432,9 @@ quit:
+   return ret;
+ }
+ 
+-GRUB_MOD_INIT (ntfscomp)
++grub_err_t
++grub_ntfscomp_func (grub_uint8_t *dest, grub_disk_addr_t ofs,
++          grub_size_t len, struct grub_ntfs_rlst *ctx)
+ {
+-  grub_ntfscomp_func = ntfscomp;
+-}
+-
+-GRUB_MOD_FINI (ntfscomp)
+-{
+-  grub_ntfscomp_func = NULL;
++    return ntfscomp(dest, ofs, len, ctx);
+ }
+diff --git a/grub-core/fs/proc.c b/grub-core/fs/proc.c
+index a03469e..ec7a87a 100644
+--- a/grub-core/fs/proc.c
++++ b/grub-core/fs/proc.c
+@@ -16,8 +16,8 @@
+  *  along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <grub/procfs.h>
+ #include <grub/disk.h>
++#include <grub/procfs.h>
+ #include <grub/fs.h>
+ #include <grub/file.h>
+ #include <grub/mm.h>
+@@ -25,6 +25,28 @@
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
++grub_disk_dev_t grub_disk_dev_list;
++
++void
++grub_disk_dev_register (grub_disk_dev_t dev)
++{
++    dev->next = grub_disk_dev_list;
++    grub_disk_dev_list = dev;
++}
++
++void
++grub_disk_dev_unregister (grub_disk_dev_t dev)
++{
++    grub_disk_dev_t *p, q;
++    
++    for (p = &grub_disk_dev_list, q = *p; q; p = &(q->next), q = q->next)
++        if (q == dev)
++        {
++            *p = q->next;
++            break;
++        }
++}
++
+ struct grub_procfs_entry *grub_procfs_entries;
+ 
+ static int
+diff --git a/grub-core/fs/reiserfs.c b/grub-core/fs/reiserfs.c
+index ac65054..7515d1b 100644
+--- a/grub-core/fs/reiserfs.c
++++ b/grub-core/fs/reiserfs.c
+@@ -42,11 +42,13 @@
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
++#undef  MIN
+ #define MIN(a, b) \
+   ({ typeof (a) _a = (a); \
+      typeof (b) _b = (b); \
+      _a < _b ? _a : _b; })
+ 
++#undef  MAX
+ #define MAX(a, b) \
+   ({ typeof (a) _a = (a); \
+      typeof (b) _b = (b); \
+diff --git a/grub-core/fs/squash4.c b/grub-core/fs/squash4.c
+index b97b344..3404b69 100644
+--- a/grub-core/fs/squash4.c
++++ b/grub-core/fs/squash4.c
+@@ -28,6 +28,7 @@
+ #include <grub/deflate.h>
+ #include <minilzo.h>
+ 
++#include "xz_config.h"
+ #include "xz.h"
+ #include "xz_stream.h"
+ 
+diff --git a/grub-core/io/gzio.c b/grub-core/io/gzio.c
+index 129209e..d60fb63 100644
+--- a/grub-core/io/gzio.c
++++ b/grub-core/io/gzio.c
+@@ -142,7 +142,11 @@ eat_field (grub_file_t file, int len)
+ /* Compression methods (see algorithm.doc) */
+ #define STORED      0
+ #define COMPRESSED  1
++#ifndef PACKED
+ #define PACKED      2
++#else /* PACKED is in use */
++#define GZPACKED    2
++#endif
+ #define LZHED       3
+ /* methods 4 to 7 reserved */
+ #define DEFLATED    8
+diff --git a/grub-core/io/xzio.c b/grub-core/io/xzio.c
+index a3536ad..41272f3 100644
+--- a/grub-core/io/xzio.c
++++ b/grub-core/io/xzio.c
+@@ -26,6 +26,7 @@
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
++#include "xz_config.h"
+ #include "xz.h"
+ #include "xz_stream.h"
+ 
+diff --git a/grub-core/kern/err.c b/grub-core/kern/err.c
+index 53c734d..4275cab 100644
+--- a/grub-core/kern/err.c
++++ b/grub-core/kern/err.c
+@@ -19,7 +19,6 @@
+ 
+ #include <grub/err.h>
+ #include <grub/misc.h>
+-#include <stdarg.h>
+ #include <grub/i18n.h>
+ 
+ #define GRUB_ERROR_STACK_SIZE	10
+diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
+index c5c815d..6c161bb 100644
+--- a/grub-core/kern/misc.c
++++ b/grub-core/kern/misc.c
+@@ -20,7 +20,6 @@
+ #include <grub/misc.h>
+ #include <grub/err.h>
+ #include <grub/mm.h>
+-#include <stdarg.h>
+ #include <grub/term.h>
+ #include <grub/env.h>
+ #include <grub/i18n.h>
+@@ -157,7 +156,6 @@ grub_puts_ (const char *s)
+   return grub_puts (_(s));
+ }
+ 
+-#if defined (__APPLE__) && ! defined (GRUB_UTIL)
+ int
+ grub_err_printf (const char *fmt, ...)
+ {
+@@ -170,7 +168,6 @@ grub_err_printf (const char *fmt, ...)
+ 
+ 	return ret;
+ }
+-#endif
+ 
+ #if ! defined (__APPLE__) && ! defined (GRUB_UTIL)
+ int grub_err_printf (const char *fmt, ...)
+diff --git a/grub-core/lib/minilzo/lzoconf.h b/grub-core/lib/minilzo/lzoconf.h
+index 1d0fe14..155b47d 100644
+--- a/grub-core/lib/minilzo/lzoconf.h
++++ b/grub-core/lib/minilzo/lzoconf.h
+@@ -44,17 +44,29 @@
+ #ifndef __LZOCONF_H_INCLUDED
+ #define __LZOCONF_H_INCLUDED 1
+ 
++#include <Uefi.h>
++#include <Library/UefiLib.h>
++#include <Library/BaseMemoryLib.h>
++
+ #define LZO_VERSION             0x2050
+ #define LZO_VERSION_STRING      "2.05"
+ #define LZO_VERSION_DATE        "Apr 23 2011"
+ 
++#define CHAR_BIT 8
++#define UCHAR_MAX 0xFF
++#define USHRT_MAX 0xFFFF
++#define ULONG_MAX 0xFFFFFFFF
++
++#if defined(MDE_CPU_IA32) || defined(MDE_CPU_ARM)
++#define UINT_MAX 0xFFFFFFFF
++#else
++#define UINT_MAX 0xFFFFFFFFFFFFFFFF
++#endif
++
+ /* internal Autoconf configuration file - only used when building LZO */
+ #if defined(LZO_HAVE_CONFIG_H)
+ #  include <config.h>
+ #endif
+-#include <limits.h>
+-#include <stddef.h>
+-
+ 
+ /***********************************************************************
+ // LZO requires a conforming <limits.h>
+@@ -118,6 +130,7 @@ extern "C" {
+      typedef unsigned __int64   lzo_uint;
+      typedef __int64            lzo_int;
+ #    else
++     typedef unsigned long long size_t;
+      typedef unsigned long long lzo_uint;
+      typedef long long          lzo_int;
+ #    endif
+@@ -125,12 +138,14 @@ extern "C" {
+ #    define LZO_INT_MAX         9223372036854775807LL
+ #    define LZO_INT_MIN         (-1LL - LZO_INT_MAX)
+ #  elif defined(LZO_ABI_IP32L64) /* MIPS R5900 */
++     typedef unsigned int       size_t;
+      typedef unsigned int       lzo_uint;
+      typedef int                lzo_int;
+ #    define LZO_UINT_MAX        UINT_MAX
+ #    define LZO_INT_MAX         INT_MAX
+ #    define LZO_INT_MIN         INT_MIN
+ #  elif (ULONG_MAX >= LZO_0xffffffffL)
++     typedef unsigned long      size_t;
+      typedef unsigned long      lzo_uint;
+      typedef long               lzo_int;
+ #    define LZO_UINT_MAX        ULONG_MAX
+diff --git a/grub-core/lib/minilzo/lzodefs.h b/grub-core/lib/minilzo/lzodefs.h
+index 0e40e33..f62bf36 100644
+--- a/grub-core/lib/minilzo/lzodefs.h
++++ b/grub-core/lib/minilzo/lzodefs.h
+@@ -664,7 +664,7 @@
+ #  endif
+ #endif
+ #if !defined(__LZO_ARCH_OVERRIDE)
+-#if (LZO_ARCH_GENERIC)
++#if (LZO_ARCH_GENERIC) || defined(MDE_CPU_EBC)
+ #  define LZO_INFO_ARCH             "generic"
+ #elif (LZO_OS_DOS16 || LZO_OS_OS216 || LZO_OS_WIN16)
+ #  define LZO_ARCH_I086             1
+@@ -676,10 +676,10 @@
+ #elif (LZO_ARCH_CRAY_MPP) && (defined(_CRAYT3D) || defined(_CRAYT3E))
+ #  define LZO_ARCH_ALPHA            1
+ #  define LZO_INFO_ARCH             "alpha"
+-#elif defined(__amd64__) || defined(__x86_64__) || defined(_M_AMD64)
++#elif defined(__amd64__) || defined(__x86_64__) || defined(_M_AMD64) || defined(MDE_CPU_X64)
+ #  define LZO_ARCH_AMD64            1
+ #  define LZO_INFO_ARCH             "amd64"
+-#elif defined(__thumb__) || (defined(_M_ARM) && defined(_M_THUMB))
++#elif defined(__thumb__) || (defined(_M_ARM) && defined(_M_THUMB)) || defined(MDE_CPU_ARM) || defined(MDE_CPU_AARCH64)
+ #  define LZO_ARCH_ARM              1
+ #  define LZO_ARCH_ARM_THUMB        1
+ #  define LZO_INFO_ARCH             "arm_thumb"
+@@ -720,7 +720,7 @@
+ #elif defined(__hppa__) || defined(__hppa)
+ #  define LZO_ARCH_HPPA             1
+ #  define LZO_INFO_ARCH             "hppa"
+-#elif defined(__386__) || defined(__i386__) || defined(__i386) || defined(_M_IX86) || defined(_M_I386)
++#elif defined(__386__) || defined(__i386__) || defined(__i386) || defined(_M_IX86) || defined(_M_I386) || defined(MDE_CPU_IA32)
+ #  define LZO_ARCH_I386             1
+ #  define LZO_ARCH_IA32             1
+ #  define LZO_INFO_ARCH             "i386"
+@@ -732,7 +732,7 @@
+ #  define LZO_ARCH_I386             1
+ #  define LZO_ARCH_IA32             1
+ #  define LZO_INFO_ARCH             "i386"
+-#elif defined(__ia64__) || defined(__ia64) || defined(_M_IA64)
++#elif defined(__ia64__) || defined(__ia64) || defined(_M_IA64) || defined(MDE_CPU_IPF)
+ #  define LZO_ARCH_IA64             1
+ #  define LZO_INFO_ARCH             "ia64"
+ #elif (UINT_MAX == LZO_0xffffL) && defined(__m32c__)
+@@ -1251,6 +1251,7 @@ extern "C" {
+ #    error "LZO_MM"
+ #  endif
+ #else
++#  define ptrdiff_t                 size_t
+ #  define LZO_SIZEOF_PTRDIFF_T      LZO_SIZEOF_SIZE_T
+ #endif
+ #endif
+diff --git a/grub-core/lib/minilzo/minilzo.c b/grub-core/lib/minilzo/minilzo.c
+index 25a1f68..f4dddb6 100644
+--- a/grub-core/lib/minilzo/minilzo.c
++++ b/grub-core/lib/minilzo/minilzo.c
+@@ -57,8 +57,7 @@
+ #ifdef MINILZO_HAVE_CONFIG_H
+ #  include <config.h>
+ #endif
+-#include <limits.h>
+-#include <stddef.h>
++
+ #if defined(MINILZO_CFG_USE_INTERNAL_LZODEFS)
+ 
+ #ifndef __LZODEFS_H_INCLUDED
+@@ -1947,7 +1946,6 @@ extern "C" {
+ #  define ACC_WANT_ACC_INCE_H 1
+ #  define ACC_WANT_ACC_INCI_H 1
+ #elif 1
+-#  include <string.h>
+ #else
+ #  define ACC_WANT_ACC_INCD_H 1
+ #endif
+@@ -1986,22 +1984,22 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_uintptr_t) >= sizeof(lzo_voidp))
+ #endif
+ #if 1 && !defined(HAVE_MEMCMP)
+ #define HAVE_MEMCMP 1
++#define memcmp CompareMem
+ #endif
+ #if 1 && !defined(HAVE_MEMCPY)
+ #define HAVE_MEMCPY 1
++#define memcpy CopyMem
+ #endif
+ #if 1 && !defined(HAVE_MEMMOVE)
+ #define HAVE_MEMMOVE 1
++#define memmove CopyMem
+ #endif
+ #if 1 && !defined(HAVE_MEMSET)
+ #define HAVE_MEMSET 1
++#define memset(s,c,n) SetMem(s,n,c)
+ #endif
+ #endif
+ 
+-#if 1 && defined(HAVE_STRING_H)
+-#include <string.h>
+-#endif
+-
+ #if (LZO_CFG_FREESTANDING)
+ #  undef HAVE_MEMCMP
+ #  undef HAVE_MEMCPY
+@@ -2011,52 +2009,41 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_uintptr_t) >= sizeof(lzo_voidp))
+ 
+ #if !(HAVE_MEMCMP)
+ #  undef memcmp
+-#  define memcmp(a,b,c)         lzo_memcmp(a,b,c)
++#  define memcmp(a,b,c)         CompareMem(a,b,c)
+ #elif !(__LZO_MMODEL_HUGE)
+ #  undef lzo_memcmp
+-#  define lzo_memcmp(a,b,c)     memcmp(a,b,c)
++#  define lzo_memcmp(a,b,c)     CompareMem(a,b,c)
+ #endif
+ #if !(HAVE_MEMCPY)
+ #  undef memcpy
+-#  define memcpy(a,b,c)         lzo_memcpy(a,b,c)
++#  define memcpy(a,b,c)         CopyMem(a,b,c)
+ #elif !(__LZO_MMODEL_HUGE)
+ #  undef lzo_memcpy
+-#  define lzo_memcpy(a,b,c)     memcpy(a,b,c)
++#  define lzo_memcpy(a,b,c)     CopyMem(a,b,c)
+ #endif
+ #if !(HAVE_MEMMOVE)
+ #  undef memmove
+-#  define memmove(a,b,c)        lzo_memmove(a,b,c)
++#  define memmove(a,b,c)        CopyMem(a,b,c)
+ #elif !(__LZO_MMODEL_HUGE)
+ #  undef lzo_memmove
+-#  define lzo_memmove(a,b,c)    memmove(a,b,c)
++#  define lzo_memmove(a,b,c)    CopyMem(a,b,c)
+ #endif
+ #if !(HAVE_MEMSET)
+ #  undef memset
+-#  define memset(a,b,c)         lzo_memset(a,b,c)
++#  define memset(s,c,n)         SetMem(s,n,c)
+ #elif !(__LZO_MMODEL_HUGE)
+ #  undef lzo_memset
+-#  define lzo_memset(a,b,c)     memset(a,b,c)
++#  define lzo_memset(s,c,n)     SetMem(s,n,c)
+ #endif
+ 
+ #undef NDEBUG
+-#if (LZO_CFG_FREESTANDING)
+-#  undef LZO_DEBUG
+-#  define NDEBUG 1
+-#  undef assert
+-#  define assert(e) ((void)0)
+-#else
+-#  if !defined(LZO_DEBUG)
+-#    define NDEBUG 1
+-#  endif
+-#  include <assert.h>
+-#endif
++#undef LZO_DEBUG
++#define NDEBUG 1
++#undef assert
++#define assert(e) ((void)0)
+ 
+-#if 0 && defined(__BOUNDS_CHECKING_ON)
+-#  include <unchecked.h>
+-#else
+-#  define BOUNDS_CHECKING_OFF_DURING(stmt)      stmt
+-#  define BOUNDS_CHECKING_OFF_IN_EXPR(expr)     (expr)
+-#endif
++#define BOUNDS_CHECKING_OFF_DURING(stmt)      stmt
++#define BOUNDS_CHECKING_OFF_IN_EXPR(expr)     (expr)
+ 
+ #if !defined(__lzo_inline)
+ #  define __lzo_inline              /*empty*/
+@@ -2470,7 +2457,7 @@ LZOLIB_PUBLIC(int, lzo_hmemcmp) (const lzo_hvoid_p s1, const lzo_hvoid_p s2, lzo
+     } while __lzo_likely(--len > 0);
+     return 0;
+ #else
+-    return memcmp(s1, s2, len);
++    return CompareMem(s1, s2, len);
+ #endif
+ }
+ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemcpy) (lzo_hvoid_p dest, const lzo_hvoid_p src, lzo_hsize_t len)
+@@ -2485,7 +2472,7 @@ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemcpy) (lzo_hvoid_p dest, const lzo_hvoid_p src
+     while __lzo_likely(--len > 0);
+     return dest;
+ #else
+-    return memcpy(dest, src, len);
++    return CopyMem(dest, src, len);
+ #endif
+ }
+ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemmove) (lzo_hvoid_p dest, const lzo_hvoid_p src, lzo_hsize_t len)
+@@ -2511,7 +2498,7 @@ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemmove) (lzo_hvoid_p dest, const lzo_hvoid_p sr
+     }
+     return dest;
+ #else
+-    return memmove(dest, src, len);
++    return CopyMem(dest, src, len);
+ #endif
+ }
+ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemset) (lzo_hvoid_p s, int c, lzo_hsize_t len)
+@@ -2523,7 +2510,7 @@ LZOLIB_PUBLIC(lzo_hvoid_p, lzo_hmemset) (lzo_hvoid_p s, int c, lzo_hsize_t len)
+     while __lzo_likely(--len > 0);
+     return s;
+ #else
+-    return memset(s, c, len);
++    return SetMem(s, len, c);
+ #endif
+ }
+ #undef LZOLIB_PUBLIC
+@@ -4559,4 +4546,3 @@ lookbehind_overrun:
+ #endif
+ 
+ /***** End of minilzo.c *****/
+-
+diff --git a/grub-core/lib/xzembed/xz.h b/grub-core/lib/xzembed/xz.h
+index fe7158b..0ecfe6f 100644
+--- a/grub-core/lib/xzembed/xz.h
++++ b/grub-core/lib/xzembed/xz.h
+@@ -24,9 +24,11 @@
+ #ifndef XZ_H
+ #define XZ_H
+ 
+-#include <stdint.h>
+-#include <unistd.h>
+-#include <string.h>
++#include <Uefi.h>
++#include <Library/UefiLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/MemoryAllocationLib.h>
++
+ #include <grub/misc.h>
+ 
+ #ifndef GRUB_POSIX_BOOL_DEFINED
+diff --git a/grub-core/lib/xzembed/xz_config.h b/grub-core/lib/xzembed/xz_config.h
+index 24d570f..9388575 100644
+--- a/grub-core/lib/xzembed/xz_config.h
++++ b/grub-core/lib/xzembed/xz_config.h
+@@ -24,6 +24,12 @@
+ #ifndef XZ_CONFIG_H
+ #define XZ_CONFIG_H
+ 
++#define uint8_t UINT8
++#define uint16_t UINT16
++#define uint32_t UINT32
++#define uint64_t UINT64
++#define size_t UINTN
++
+ /* Enable BCJ filter decoders. */
+ 
+ #ifndef GRUB_EMBED_DECOMPRESSOR
+@@ -37,7 +43,7 @@
+ 
+ #else
+ 
+-#if defined(__i386__) || defined(__x86_64__)
++#if defined(__i386__) || defined(__x86_64__) || defined(MDE_CPU_IA32) || defined(MDE_CPU_X64) || defined(MDE_CPU_EBC)
+   #define XZ_DEC_X86
+ #endif
+ 
+@@ -45,15 +51,15 @@
+   #define XZ_DEC_POWERPC
+ #endif
+ 
+-#ifdef __ia64__
++#if defined(__ia64__) || defined(MDE_CPU_IPF)
+   #define XZ_DEC_IA64
+ #endif
+ 
+-#ifdef __arm__
++#if defined(__arm__) || defined(MDE_CPU_ARM) || defined(MDE_CPU_AARCH64)
+   #define XZ_DEC_ARM
+ #endif
+ 
+-#ifdef __arm__
++#if defined(__arm__) || defined(MDE_CPU_ARM) || defined(MDE_CPU_AARCH64)
+   #define XZ_DEC_ARMTHUMB
+ #endif
+ 
+@@ -63,15 +69,16 @@
+ #endif
+ 
+ #include "xz.h"
+-#include <stdlib.h>
+ 
+-#define kmalloc(size, flags) malloc(size)
+-#define kfree(ptr) free(ptr)
+-#define vmalloc(size) malloc(size)
+-#define vfree(ptr) free(ptr)
++#define realloc(p, s) ReallocatePool ((UINTN)s, (UINTN)s, p)
++#define kmalloc(size, flags) AllocateZeroPool(size)
++#define kfree(ptr) FreePool(ptr)
++#define vmalloc(size) AllocateZeroPool(size)
++#define vfree(ptr) FreePool(ptr)
+ 
+-#define memeq(a, b, size) (memcmp(a, b, size) == 0)
+-#define memzero(buf, size) memset(buf, 0, size)
++#define memeq(a, b, size) (CompareMem(a, b, size) == 0)
++#define memzero(buf, size) CopyMem(buf, 0, size)
++#define memcpy(tbuf, buf, size) CopyMem(tbuf, buf, size)
+ 
+ #define min(x, y) ((x) < (y) ? (x) : (y))
+ #define min_t(type, x, y) min(x, y)
+diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
+index e5dd543..4de82a2 100644
+--- a/include/grub/efi/api.h
++++ b/include/grub/efi/api.h
+@@ -111,10 +111,12 @@
+     { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+   }
+ 
++#ifndef EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
+ #define EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID \
+   { 0xdd9e7534, 0x7762, 0x4698, \
+     { 0x8c, 0x14, 0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa } \
+   }
++#endif
+ 
+ #define GRUB_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_GUID \
+   { 0x387477c2, 0x69c7, 0x11d2, \
+diff --git a/include/grub/hfsplus.h b/include/grub/hfsplus.h
+index 8ba8f32..601fd49 100644
+--- a/include/grub/hfsplus.h
++++ b/include/grub/hfsplus.h
+@@ -229,8 +229,8 @@ grub_hfsplus_btree_recptr (struct grub_hfsplus_btree *btree,
+   return (struct grub_hfsplus_key *) &cnode[offset];
+ }
+ 
+-extern grub_err_t (*grub_hfsplus_open_compressed) (struct grub_hfsplus_file *node);
+-extern grub_ssize_t (*grub_hfsplus_read_compressed) (struct grub_hfsplus_file *node,
++extern grub_err_t grub_hfsplus_open_compressed (struct grub_hfsplus_file *node);
++extern grub_ssize_t grub_hfsplus_read_compressed (struct grub_hfsplus_file *node,
+ 						     grub_off_t pos,
+ 						     grub_size_t len,
+ 						     char *buf);
+diff --git a/include/grub/misc.h b/include/grub/misc.h
+index c6cd456..405ff90 100644
+--- a/include/grub/misc.h
++++ b/include/grub/misc.h
+@@ -20,13 +20,24 @@
+ #ifndef GRUB_MISC_HEADER
+ #define GRUB_MISC_HEADER	1
+ 
+-#include <stdarg.h>
++//#include <stdarg.h>
+ #include <grub/types.h>
+ #include <grub/symbol.h>
+ #include <grub/err.h>
+ #include <grub/i18n.h>
+ #include <grub/compiler.h>
+ 
++#define va_list VA_LIST
++#define va_start VA_START
++#define va_end VA_END
++#define va_arg VA_ARG
++#define memcmp CompareMem
++#define strcpy AsciiStrCpy
++#define memmove CopyMem
++#define memset(s,c,n) SetMem(s,n,c)
++#define bzero(s,n) SetMem(s,n,0)
++#define __bzero(s,n) SetMem(s,n,0)
++
+ #define ALIGN_UP(addr, align) \
+ 	((addr + (typeof (addr)) align - 1) & ~((typeof (addr)) align - 1))
+ #define ALIGN_UP_OVERHEAD(addr, align) ((-(addr)) & ((typeof (addr)) (align) - 1))
+diff --git a/include/grub/ntfs.h b/include/grub/ntfs.h
+index d1a6af6..a99437b 100644
+--- a/include/grub/ntfs.h
++++ b/include/grub/ntfs.h
+@@ -186,13 +186,11 @@ struct grub_ntfs_rlst
+   void *file;
+ };
+ 
+-typedef grub_err_t (*grub_ntfscomp_func_t) (grub_uint8_t *dest,
++grub_err_t grub_ntfscomp_func (grub_uint8_t *dest,
+ 					    grub_disk_addr_t ofs,
+ 					    grub_size_t len,
+ 					    struct grub_ntfs_rlst * ctx);
+ 
+-extern grub_ntfscomp_func_t grub_ntfscomp_func;
+-
+ grub_err_t grub_ntfs_read_run_list (struct grub_ntfs_rlst *ctx);
+ 
+ #endif /* ! GRUB_NTFS_H */
+-- 
+2.8.1.windows.1
+

--- a/efifs.dec
+++ b/efifs.dec
@@ -1,0 +1,27 @@
+## @file 
+#
+# This Package provides all definitions(including functions, MACROs, structures and library classes)
+# and libraries instances, which are only used by Duet platform.
+#
+# Copyright (c) 2007 - 2011, Intel Corporation. All rights reserved.<BR>
+#
+# This program and the accompanying materials are licensed and made available under
+# the terms and conditions of the BSD License which accompanies this distribution.
+# The full text of the license may be found at
+# http://opensource.org/licenses/bsd-license.php
+#
+# THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+# WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION              = 0x00010005
+  PACKAGE_NAME                   = efifs
+  PACKAGE_GUID                   = D65E40B8-BC4B-4625-9E5C-17C5726C39C3
+  PACKAGE_VERSION                = 0.6
+
+[Includes]
+  grub/include
+  grub
+  grub/grub-core/lib/minilzo 

--- a/src/AFFS.inf
+++ b/src/AFFS.inf
@@ -1,0 +1,77 @@
+# $Id: AFFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# AFFS - efifs AFFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = AFFS
+        FILE_GUID                  = BD873114-A318-48C4-AEF9-6C9E43A50FFA
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/affs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFFS.efi\" -DDRIVERNAME=affs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFFS.efi\" -DDRIVERNAME=affs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFFS.efi\" -DDRIVERNAME=affs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFFS.efi\" -DDRIVERNAME=affs -Os

--- a/src/AFS.inf
+++ b/src/AFS.inf
@@ -1,0 +1,77 @@
+# $Id: AFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# AFS - efifs AFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = AFS
+        FILE_GUID                  = DEFE2F9E-38C4-4278-AB7D-3BCC7B3C9292
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/afs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFS.efi\" -DDRIVERNAME=afs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFS.efi\" -DDRIVERNAME=afs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFS.efi\" -DDRIVERNAME=afs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"AFS.efi\" -DDRIVERNAME=afs -Os

--- a/src/BFS.inf
+++ b/src/BFS.inf
@@ -1,0 +1,77 @@
+# $Id: BFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# BFS - efifs BFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = BFS
+        FILE_GUID                  = 7686EACB-461E-417F-BB6B-0C5DBA8B4087
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/bfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BFS.efi\" -DDRIVERNAME=bfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BFS.efi\" -DDRIVERNAME=bfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BFS.efi\" -DDRIVERNAME=bfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BFS.efi\" -DDRIVERNAME=bfs -Os

--- a/src/BTRFS.inf
+++ b/src/BTRFS.inf
@@ -1,0 +1,81 @@
+# $Id: BTRFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# BTRFS - efifs BTRFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = BTRFS
+        FILE_GUID                  = E4FD4F23-5515-434C-9F19-59CA8B122825
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/lib/crc.c
+	../grub/grub-core/lib/minilzo/minilzo.c
+	../grub/grub-core/io/lzopio.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/btrfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BTRFS.efi\" -DDRIVERNAME=btrfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BTRFS.efi\" -DDRIVERNAME=btrfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BTRFS.efi\" -DDRIVERNAME=btrfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"BTRFS.efi\" -DDRIVERNAME=btrfs -Os

--- a/src/CBFS.inf
+++ b/src/CBFS.inf
@@ -1,0 +1,80 @@
+# $Id: CBFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# CBFS - efifs CBFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = CBFS
+        FILE_GUID                  = DEEC0FF0-64AE-4B2D-A9D1-87057258854C
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/file.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/cbfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CBFS.efi\" -DDRIVERNAME=cbfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CBFS.efi\" -DDRIVERNAME=cbfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CBFS.efi\" -DDRIVERNAME=cbfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CBFS.efi\" -DDRIVERNAME=cbfs -Os

--- a/src/CPIO.inf
+++ b/src/CPIO.inf
@@ -1,0 +1,78 @@
+# $Id: CPIO.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# CPIO - efifs CPIO driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = CPIO
+        FILE_GUID                  = FE902772-06CD-40E4-B35B-0E760C5E9C1A
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/cpio.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO.efi\" -DDRIVERNAME=cpio -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO.efi\" -DDRIVERNAME=cpio -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO.efi\" -DDRIVERNAME=cpio -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO.efi\" -DDRIVERNAME=cpio -Os

--- a/src/CPIO_BE.inf
+++ b/src/CPIO_BE.inf
@@ -1,0 +1,78 @@
+# $Id: CPIO_BE.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# CPIO_BE - efifs CPIO_BE driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = CPIO_BE
+        FILE_GUID                  = A3853AE0-E77D-405E-8A75-16333DE1632C
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/cpio_be.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO_BE.efi\" -DDRIVERNAME=cpio_be -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO_BE.efi\" -DDRIVERNAME=cpio_be -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO_BE.efi\" -DDRIVERNAME=cpio_be -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"CPIO_BE.efi\" -DDRIVERNAME=cpio_be -Os

--- a/src/EXFAT.inf
+++ b/src/EXFAT.inf
@@ -1,0 +1,77 @@
+# $Id: EXFAT.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# EXFAT - efifs EXFAT driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = EXFAT
+        FILE_GUID                  = B9E0C839-BF75-4889-82FF-214BED41BA47
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/exfat.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXFAT.efi\" -DDRIVERNAME=exfat -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXFAT.efi\" -DDRIVERNAME=exfat -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXFAT.efi\" -DDRIVERNAME=exfat -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXFAT.efi\" -DDRIVERNAME=exfat -Os

--- a/src/EXT2.inf
+++ b/src/EXT2.inf
@@ -1,0 +1,77 @@
+# $Id: EXT2.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# EXT2 - efifs EXT2 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = EXT2
+        FILE_GUID                  = 7DDA7772-B8F5-4859-9DBA-0D6F2DBA4AF1
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/ext2.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXT2.efi\" -DDRIVERNAME=ext2 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXT2.efi\" -DDRIVERNAME=ext2 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXT2.efi\" -DDRIVERNAME=ext2 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"EXT2.efi\" -DDRIVERNAME=ext2 -Os

--- a/src/FAT.inf
+++ b/src/FAT.inf
@@ -1,0 +1,77 @@
+# $Id: FAT.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# FAT - efifs FAT driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = FAT
+        FILE_GUID                  = 2920E524-AD21-499E-9F4A-466BFDC3BFFB
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/fat.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"FAT.efi\" -DDRIVERNAME=fat -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"FAT.efi\" -DDRIVERNAME=fat -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"FAT.efi\" -DDRIVERNAME=fat -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"FAT.efi\" -DDRIVERNAME=fat -Os

--- a/src/HFS.inf
+++ b/src/HFS.inf
@@ -1,0 +1,77 @@
+# $Id: HFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# HFS - efifs HFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = HFS
+        FILE_GUID                  = BB57B5D8-F6DE-481C-9B08-C779B0F33E25
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/hfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFS.efi\" -DDRIVERNAME=hfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFS.efi\" -DDRIVERNAME=hfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFS.efi\" -DDRIVERNAME=hfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFS.efi\" -DDRIVERNAME=hfs -Os

--- a/src/HFSPLUS.inf
+++ b/src/HFSPLUS.inf
@@ -1,0 +1,79 @@
+# $Id: HFSPLUS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# HFSPLUS - efifs HFSPLUS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = HFSPLUS
+        FILE_GUID                  = EE593365-0635-44FC-AF28-DB98B63FDBC6
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/hfspluscomp.c
+	../grub/grub-core/fs/hfsplus.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFSPLUS.efi\" -DDRIVERNAME=hfsplus -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFSPLUS.efi\" -DDRIVERNAME=hfsplus -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFSPLUS.efi\" -DDRIVERNAME=hfsplus -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"HFSPLUS.efi\" -DDRIVERNAME=hfsplus -Os

--- a/src/ISO9660.inf
+++ b/src/ISO9660.inf
@@ -1,0 +1,77 @@
+# $Id: ISO9660.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# ISO9660 - efifs ISO9660 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = ISO9660
+        FILE_GUID                  = EFBE987A-A33B-4EE4-B2B5-35DEDC28A5E9
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/iso9660.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ISO9660.efi\" -DDRIVERNAME=iso9660 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ISO9660.efi\" -DDRIVERNAME=iso9660 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ISO9660.efi\" -DDRIVERNAME=iso9660 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ISO9660.efi\" -DDRIVERNAME=iso9660 -Os

--- a/src/JFS.inf
+++ b/src/JFS.inf
@@ -1,0 +1,77 @@
+# $Id: JFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# JFS - efifs JFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = JFS
+        FILE_GUID                  = E87CF4E3-318E-4B5F-98B9-A6B47414506D
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/jfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"JFS.efi\" -DDRIVERNAME=jfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"JFS.efi\" -DDRIVERNAME=jfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"JFS.efi\" -DDRIVERNAME=jfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"JFS.efi\" -DDRIVERNAME=jfs -Os

--- a/src/MINIX.inf
+++ b/src/MINIX.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX - efifs MINIX driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX
+        FILE_GUID                  = 16CE8469-1586-4CE0-B90C-88D049A2967B
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX.efi\" -DDRIVERNAME=minix -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX.efi\" -DDRIVERNAME=minix -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX.efi\" -DDRIVERNAME=minix -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX.efi\" -DDRIVERNAME=minix -Os

--- a/src/MINIX2.inf
+++ b/src/MINIX2.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX2.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX2 - efifs MINIX2 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX2
+        FILE_GUID                  = 0AF860D2-4089-496A-AB51-2F28730E5CF6
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix2.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2.efi\" -DDRIVERNAME=minix2 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2.efi\" -DDRIVERNAME=minix2 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2.efi\" -DDRIVERNAME=minix2 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2.efi\" -DDRIVERNAME=minix2 -Os

--- a/src/MINIX2_BE.inf
+++ b/src/MINIX2_BE.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX2_BE.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX2_BE - efifs MINIX2_BE driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX2_BE
+        FILE_GUID                  = 0974F29A-42B5-4B32-A9E6-7BB42BE57B84
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix2_be.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2_BE.efi\" -DDRIVERNAME=minix2_be -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2_BE.efi\" -DDRIVERNAME=minix2_be -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2_BE.efi\" -DDRIVERNAME=minix2_be -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX2_BE.efi\" -DDRIVERNAME=minix2_be -Os

--- a/src/MINIX3.inf
+++ b/src/MINIX3.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX3.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX3 - efifs MINIX3 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX3
+        FILE_GUID                  = 8DE9E73E-B120-49AA-960B-FC18FCEAAB3A
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix3.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3.efi\" -DDRIVERNAME=minix3 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3.efi\" -DDRIVERNAME=minix3 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3.efi\" -DDRIVERNAME=minix3 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3.efi\" -DDRIVERNAME=minix3 -Os

--- a/src/MINIX3_BE.inf
+++ b/src/MINIX3_BE.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX3_BE.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX3_BE - efifs MINIX3_BE driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX3_BE
+        FILE_GUID                  = 9C3DB9FC-7B1A-4534-B5B9-C21E56EE7BA6
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix3_be.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3_BE.efi\" -DDRIVERNAME=minix3_be -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3_BE.efi\" -DDRIVERNAME=minix3_be -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3_BE.efi\" -DDRIVERNAME=minix3_be -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX3_BE.efi\" -DDRIVERNAME=minix3_be -Os

--- a/src/MINIX_BE.inf
+++ b/src/MINIX_BE.inf
@@ -1,0 +1,77 @@
+# $Id: MINIX_BE.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# MINIX_BE - efifs MINIX_BE driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = MINIX_BE
+        FILE_GUID                  = 5B677870-CF38-4892-AF77-AA5C9695DFBB
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/minix_be.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX_BE.efi\" -DDRIVERNAME=minix_be -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX_BE.efi\" -DDRIVERNAME=minix_be -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX_BE.efi\" -DDRIVERNAME=minix_be -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"MINIX_BE.efi\" -DDRIVERNAME=minix_be -Os

--- a/src/NEWC.inf
+++ b/src/NEWC.inf
@@ -1,0 +1,78 @@
+# $Id: NEWC.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# NEWC - efifs NEWC driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = NEWC
+        FILE_GUID                  = 5C0F70A7-DC33-4A82-9056-924E83E33F01
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/newc.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NEWC.efi\" -DDRIVERNAME=newc -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NEWC.efi\" -DDRIVERNAME=newc -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NEWC.efi\" -DDRIVERNAME=newc -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NEWC.efi\" -DDRIVERNAME=newc -Os

--- a/src/NILFS2.inf
+++ b/src/NILFS2.inf
@@ -1,0 +1,77 @@
+# $Id: NILFS2.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# NILFS2 - efifs NILFS2 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = NILFS2
+        FILE_GUID                  = E6BCED0B-96E0-4BD7-AF96-65467ABAAC6E
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/nilfs2.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NILFS2.efi\" -DDRIVERNAME=nilfs2 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NILFS2.efi\" -DDRIVERNAME=nilfs2 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NILFS2.efi\" -DDRIVERNAME=nilfs2 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NILFS2.efi\" -DDRIVERNAME=nilfs2 -Os

--- a/src/NTFS.inf
+++ b/src/NTFS.inf
@@ -1,0 +1,78 @@
+# $Id: NTFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# NTFS - efifs NTFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = NTFS
+        FILE_GUID                  = 80FB68D4-7C52-4AFE-A91E-D3DDADB5C54F
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/ntfscomp.c
+	../grub/grub-core/fs/ntfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NTFS.efi\" -DDRIVERNAME=ntfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NTFS.efi\" -DDRIVERNAME=ntfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NTFS.efi\" -DDRIVERNAME=ntfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"NTFS.efi\" -DDRIVERNAME=ntfs -Os

--- a/src/ODC.inf
+++ b/src/ODC.inf
@@ -1,0 +1,78 @@
+# $Id: ODC.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# ODC - efifs ODC driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = ODC
+        FILE_GUID                  = FC117DCB-B369-46B7-A84E-E34EF821756C
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/odc.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ODC.efi\" -DDRIVERNAME=odc -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ODC.efi\" -DDRIVERNAME=odc -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ODC.efi\" -DDRIVERNAME=odc -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ODC.efi\" -DDRIVERNAME=odc -Os

--- a/src/PROC.inf
+++ b/src/PROC.inf
@@ -1,0 +1,78 @@
+# $Id: PROC.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# PROC - efifs PROC driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = PROC
+        FILE_GUID                  = 4F59B6B8-8FED-41B4-A970-CCBAF0F684DF
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/file.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/proc.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"PROC.efi\" -DDRIVERNAME=procfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"PROC.efi\" -DDRIVERNAME=procfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"PROC.efi\" -DDRIVERNAME=procfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"PROC.efi\" -DDRIVERNAME=procfs -Os

--- a/src/REISERFS.inf
+++ b/src/REISERFS.inf
@@ -1,0 +1,77 @@
+# $Id: REISERFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# REISERFS - efifs REISERFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = REISERFS
+        FILE_GUID                  = 8B20B75F-5AAB-4839-A5F2-2843653BDEFF
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/reiserfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"REISERFS.efi\" -DDRIVERNAME=reiserfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"REISERFS.efi\" -DDRIVERNAME=reiserfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"REISERFS.efi\" -DDRIVERNAME=reiserfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"REISERFS.efi\" -DDRIVERNAME=reiserfs -Os

--- a/src/ROMFS.inf
+++ b/src/ROMFS.inf
@@ -1,0 +1,77 @@
+# $Id: ROMFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# ROMFS - efifs ROMFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = ROMFS
+        FILE_GUID                  = A57C00D8-2766-4DDF-AC8D-BAC89472F255
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/romfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ROMFS.efi\" -DDRIVERNAME=romfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ROMFS.efi\" -DDRIVERNAME=romfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ROMFS.efi\" -DDRIVERNAME=romfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ROMFS.efi\" -DDRIVERNAME=romfs -Os

--- a/src/SFS.inf
+++ b/src/SFS.inf
@@ -1,0 +1,77 @@
+# $Id: SFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# SFS - efifs SFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = SFS
+        FILE_GUID                  = 0093FDD4-86D8-457C-82C9-2832321BB8B5
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/sfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SFS.efi\" -DDRIVERNAME=sfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SFS.efi\" -DDRIVERNAME=sfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SFS.efi\" -DDRIVERNAME=sfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SFS.efi\" -DDRIVERNAME=sfs -Os

--- a/src/SQUASH4.inf
+++ b/src/SQUASH4.inf
@@ -1,0 +1,86 @@
+# $Id: SQUASH4.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# SQUASH4 - efifs SQUASH4 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = SQUASH4
+        FILE_GUID                  = F85516B3-FEAD-4D5B-9E4A-9A476ABA65CA
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/lib/crc.c
+	../grub/grub-core/lib/crypto.c
+	../grub/grub-core/lib/xzembed/xz_dec_bcj.c
+	../grub/grub-core/lib/xzembed/xz_dec_lzma2.c
+	../grub/grub-core/lib/xzembed/xz_dec_stream.c
+	../grub/grub-core/lib/minilzo/minilzo.c
+	../grub/grub-core/io/lzopio.c
+	../grub/grub-core/io/xzio.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/squash4.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SQUASH4.efi\" -DDRIVERNAME=squash4 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SQUASH4.efi\" -DDRIVERNAME=squash4 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SQUASH4.efi\" -DDRIVERNAME=squash4 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"SQUASH4.efi\" -DDRIVERNAME=squash4 -Os

--- a/src/TAR.inf
+++ b/src/TAR.inf
@@ -1,0 +1,79 @@
+# $Id: TAR.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# TAR - efifs TAR driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = TAR
+        FILE_GUID                  = 5FA5BB28-C228-48BC-BEED-4137E56B5C32
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/archelp.c
+	../grub/grub-core/fs/tar.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"TAR.efi\" -DDRIVERNAME=tar -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"TAR.efi\" -DDRIVERNAME=tar -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"TAR.efi\" -DDRIVERNAME=tar -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"TAR.efi\" -DDRIVERNAME=tar -Os

--- a/src/UDF.inf
+++ b/src/UDF.inf
@@ -1,0 +1,77 @@
+# $Id: UDF.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# UDF - efifs UDF driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = UDF
+        FILE_GUID                  = 3E1C5997-2AED-4A6C-A8BF-07882633D1FB
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/udf.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UDF.efi\" -DDRIVERNAME=udf -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UDF.efi\" -DDRIVERNAME=udf -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UDF.efi\" -DDRIVERNAME=udf -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UDF.efi\" -DDRIVERNAME=udf -Os

--- a/src/UFS.inf
+++ b/src/UFS.inf
@@ -1,0 +1,77 @@
+# $Id: UFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# UFS - efifs UFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = UFS
+        FILE_GUID                  = CFC9DAEA-DBB4-4A5A-8034-D0ABF2849DF3
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/ufs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS.efi\" -DDRIVERNAME=ufs1 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS.efi\" -DDRIVERNAME=ufs1 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS.efi\" -DDRIVERNAME=ufs1 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS.efi\" -DDRIVERNAME=ufs1 -Os

--- a/src/UFS2.inf
+++ b/src/UFS2.inf
@@ -1,0 +1,77 @@
+# $Id: UFS2.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# UFS2 - efifs UFS2 driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = UFS2
+        FILE_GUID                  = 15ED2F4C-1EB8-4B4F-826B-73D83EDAA449
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/ufs2.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS2.efi\" -DDRIVERNAME=ufs2 -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS2.efi\" -DDRIVERNAME=ufs2 -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS2.efi\" -DDRIVERNAME=ufs2 -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS2.efi\" -DDRIVERNAME=ufs2 -Os

--- a/src/UFS_BE.inf
+++ b/src/UFS_BE.inf
@@ -1,0 +1,77 @@
+# $Id: UFS_BE.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# UFS_BE - efifs UFS_BE driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = UFS_BE
+        FILE_GUID                  = F3B03ADF-0595-483C-BF15-0C39A444345C
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/ufs_be.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS_BE.efi\" -DDRIVERNAME=ufs1_be -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS_BE.efi\" -DDRIVERNAME=ufs1_be -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS_BE.efi\" -DDRIVERNAME=ufs1_be -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"UFS_BE.efi\" -DDRIVERNAME=ufs1_be -Os

--- a/src/XFS.inf
+++ b/src/XFS.inf
@@ -1,0 +1,77 @@
+# $Id: XFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# XFS - efifs XFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = XFS
+        FILE_GUID                  = 8F56A526-1566-442F-9D7F-3E704772B75A
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/xfs.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"XFS.efi\" -DDRIVERNAME=xfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"XFS.efi\" -DDRIVERNAME=xfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"XFS.efi\" -DDRIVERNAME=xfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"XFS.efi\" -DDRIVERNAME=xfs -Os

--- a/src/ZFS.inf
+++ b/src/ZFS.inf
@@ -1,0 +1,84 @@
+# $Id: ZFS.inf 29125 2010-05-06 09:43:05Z efifs $
+## @file
+# ZFS - efifs ZFS driver.
+#
+
+[Defines]
+        INF_VERSION                = 0x00010005
+        BASE_NAME                  = ZFS
+        FILE_GUID                  = 0F6A96E7-0F76-4947-90DB-D4FD7A7E6147
+        MODULE_TYPE                = UEFI_DRIVER
+        VERSION_STRING             = 1.0
+        EDK_RELEASE_VERSION        = 0x00020000
+        EFI_SPECIFICATION_VERSION  = 0x00020000
+
+        ENTRY_POINT                = FSDriverInstall
+
+[Sources.common]
+        driver.c
+        file.c
+        grub_driver.c
+        grub_file.c
+        grub.c
+	logging.c
+	missing.c
+	path.c
+	utf8.c
+	../grub/grub-core/io/gzio.c
+	../grub/grub-core/kern/device.c
+	../grub/grub-core/kern/err.c
+	../grub/grub-core/kern/misc.c
+	../grub/grub-core/kern/list.c
+	../grub/grub-core/fs/fshelp.c
+	../grub/grub-core/fs/zfs/zfs.c
+	../grub/grub-core/fs/zfs/zfs_fletcher.c
+	../grub/grub-core/fs/zfs/zfs_lz4.c
+	../grub/grub-core/fs/zfs/zfs_lzjb.c
+	../grub/grub-core/fs/zfs/zfs_sha256.c
+	../grub/grub-core/fs/zfs/zfscrypt.c
+	../grub/grub-core/fs/zfs/zfsinfo.c
+
+[Packages]
+        MdePkg/MdePkg.dec
+        ShellPkg/ShellPkg.dec
+        IntelFrameworkModulePkg/IntelFrameworkModulePkg.dec
+        Clover/CloverPkg.dec
+	Clover/efifs/efifs.dec
+
+[LibraryClasses]
+   UefiRuntimeServicesTableLib
+   UefiBootServicesTableLib
+   MemoryAllocationLib
+   BaseMemoryLib
+   BaseLib
+   UefiLib
+   UefiDriverEntryPoint
+   DebugLib
+   PcdLib
+
+[Guids]
+  gEfiFileInfoGuid
+  gEfiFileSystemInfoGuid
+  gEfiFileSystemVolumeLabelInfoIdGuid
+
+[Protocols]
+  gEfiDiskIoProtocolGuid
+  gEfiDiskIo2ProtocolGuid
+  gEfiBlockIoProtocolGuid
+  gEfiBlockIo2ProtocolGuid
+  gEfiSimpleFileSystemProtocolGuid
+  gEfiUnicodeCollationProtocolGuid
+  gEfiUnicodeCollation2ProtocolGuid
+  gMsgLogProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLang
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultPlatformLang
+
+[BuildOptions.common]
+  *_*_IA32_CC_FLAGS = -DFORMAT=efi-app-ia32
+  *_*_X64_CC_FLAGS = -DFORMAT=efi-app-x64
+  GCC:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ZFS.efi\" -DDRIVERNAME=zfs -Os
+  XCODE:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ZFS.efi\" -DDRIVERNAME=zfs -Os
+  IBTEL:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ZFS.efi\" -DDRIVERNAME=zfs -Os
+  MSFT:*_*_*_CC_FLAGS = -DCPU_$(ARCH) -DMDEPKG_NDEBUG -DGRUB_MACHINE_EFI -DGRUB_KERNEL -DGRUB_UTIL -DGRUB_FILE=\"ZFS.efi\" -DDRIVERNAME=zfs -Os

--- a/src/grub.c
+++ b/src/grub.c
@@ -18,9 +18,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
-
 #include <grub/err.h>
 #include <grub/misc.h>
 
@@ -131,7 +128,7 @@ grub_realloc(void *p, grub_size_t new_size)
 
 	if (ptr != NULL) {
 		ptr = &ptr[-1];
-		ptr = ReallocatePool(ptr, *ptr, new_size + sizeof(grub_size_t));
+		ptr = ReallocatePool(*ptr, new_size + sizeof(grub_size_t), ptr);
 		if (ptr != NULL)
 			*ptr++ = new_size;
 	}

--- a/src/grub_file.c
+++ b/src/grub_file.c
@@ -18,10 +18,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
-#include <efidebug.h>	/* ASSERT */
-
 #include <grub/err.h>
 #include <grub/misc.h>
 #include <grub/disk.h>
@@ -143,16 +139,29 @@ grub_disk_read(grub_disk_t disk, grub_disk_addr_t sector,
 {
 	EFI_STATUS Status;
 	EFI_FS* FileSystem = (EFI_FS *) disk->data;
+    EFI_BLOCK_IO_MEDIA *Media;
 
 	ASSERT(FileSystem != NULL);
 	ASSERT(FileSystem->DiskIo != NULL);
 	ASSERT(FileSystem->BlockIo != NULL);
 
+    if (FileSystem->BlockIo2 != NULL)
+    {
+      Media = FileSystem->BlockIo2->Media;
+    } else {
+      Media = FileSystem->BlockIo->Media;
+    }
 	/* NB: We could get the actual blocksize through FileSystem->BlockIo->Media->BlockSize
 	 * but GRUB uses the fixed GRUB_DISK_SECTOR_SIZE, so we follow suit
 	 */
-	Status = FileSystem->DiskIo->ReadDisk(FileSystem->DiskIo, FileSystem->BlockIo->Media->MediaId,
+    if (FileSystem->DiskIo2 != NULL)
+    {
+      Status = FileSystem->DiskIo2->ReadDiskEx(FileSystem->DiskIo2, Media->MediaId,
+                                               sector * GRUB_DISK_SECTOR_SIZE + offset, &(FileSystem->DiskIo2Token), size, buf);
+    } else {
+        Status = FileSystem->DiskIo->ReadDisk(FileSystem->DiskIo, Media->MediaId,
 			sector * GRUB_DISK_SECTOR_SIZE + offset, size, buf);
+    }
 
 	if (EFI_ERROR(Status)) {
 		PrintStatusError(Status, L"Could not read block at address %08x", sector);
@@ -169,6 +178,12 @@ grub_disk_get_size (grub_disk_t disk)
 
 	ASSERT(FileSystem != NULL);
 	ASSERT(FileSystem->BlockIo != NULL);
+
+    if (FileSystem->BlockIo2 != NULL)
+    {
+      return (FileSystem->BlockIo2->Media->LastBlock + 1) *
+        FileSystem->BlockIo2->Media->BlockSize;
+    }
 
 	return (FileSystem->BlockIo->Media->LastBlock + 1) *
 			FileSystem->BlockIo->Media->BlockSize;
@@ -188,8 +203,8 @@ grub_device_open(const char *name)
 			grub_printf("Could not convert device '%s' to UTF-16\n", name);
 		return NULL;
 	}
-	for (FileSystem = (EFI_FS *) FsListHead.Flink; FileSystem != (EFI_FS *) &FsListHead;
-			FileSystem = (EFI_FS *) FileSystem->Flink) {
+	for (FileSystem = (EFI_FS *) FsListHead.ForwardLink; FileSystem != (EFI_FS *) &FsListHead;
+			FileSystem = (EFI_FS *) FileSystem->ForwardLink) {
 		if (StrCmp(FileSystem->DevicePathString, Name) == 0) 
 			break;
 	}
@@ -240,7 +255,7 @@ GrubDeviceInit(EFI_FS *FileSystem)
 	FreePool(name);
 
 	if (FileSystem->GrubDevice == NULL) {
-		RemoveEntryList(FileSystem);
+		RemoveEntryList((LIST_ENTRY *)FileSystem);
 		return EFI_NOT_FOUND;
 	}
 
@@ -251,7 +266,7 @@ EFI_STATUS
 GrubDeviceExit(EFI_FS *FileSystem)
 {
 	grub_device_close((grub_device_t) FileSystem->GrubDevice);
-	RemoveEntryList(FileSystem);
+	RemoveEntryList((LIST_ENTRY *)FileSystem);
 
 	return EFI_SUCCESS;
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,6 +1,6 @@
 /* logging.c - EFI logging */
 /*
- *  Copyright © 2014 Pete Batard <pete@akeo.ie>
+ *  Copyright ï¿½ 2014 Pete Batard <pete@akeo.ie>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,10 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
-#include <efistdarg.h>
-#include <edk2/ShellVariableGuid.h>
+#include <Guid/ShellVariableGuid.h>
 
 #include "driver.h"
 
@@ -51,17 +48,19 @@ INTN LogLevel = DEFAULT_LOGLEVEL;
 VOID
 PrintStatusError(EFI_STATUS Status, const CHAR16 *Format, ...)
 {
-	CHAR16 StatusString[64];
 	va_list ap;
+    CHAR8 *param;
 
 	if (LogLevel < FS_LOGLEVEL_ERROR)
 		return;
 
-	StatusToString(StatusString, Status);
 	va_start(ap, Format);
-	VPrint((CHAR16 *)Format, ap);
+    while ((param = VA_ARG(ap, CHAR8 *)) != NULL)
+    {
+      AsciiPrint(param);
+    }
 	va_end(ap);
-	Print(L": [%d] %s\n", Status, StatusString); 
+	Print(L": [%d]\n", Status);
 }
 
 /* You can control the verbosity of the driver output by setting the shell environment
@@ -72,14 +71,14 @@ SetLogging(VOID)
 {
 	EFI_STATUS Status;
 	CHAR16 LogVar[4];
-	UINTN i, LogVarSize = sizeof(LogVar);
+	UINTN /*i,*/ LogVarSize = sizeof(LogVar);
 
 	Status = RT->GetVariable(L"FS_LOGGING", &ShellVariable, NULL, &LogVarSize, LogVar);
 	if (Status == EFI_SUCCESS)
 		LogLevel = Atoi(LogVar);
 
-	for (i=0; i<ARRAYSIZE(PrintTable); i++)
-		*PrintTable[i] = (i < LogLevel)?Print:PrintNone;
+	/*for (i=0; i<ARRAYSIZE(PrintTable); i++)
+		*PrintTable[i] = (i < LogLevel) ? Print : PrintNone;*/
 
 	PrintExtra(L"LogLevel = %d\n", LogLevel);
 }

--- a/src/missing.c
+++ b/src/missing.c
@@ -1,8 +1,8 @@
 /* missing.c - Missing convenience calls from the EFI interface */
 /*
- *  Copyright © 2014 Pete Batard <pete@akeo.ie>
+ *  Copyright ï¿½ 2014 Pete Batard <pete@akeo.ie>
  *  Based on GRUB  --  GRand Unified Bootloader
- *  Copyright © 1999-2010 Free Software Foundation, Inc.
+ *  Copyright ï¿½ 1999-2010 Free Software Foundation, Inc.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,8 +18,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
+#include "driver.h"
 
 VOID
 strcpya(CHAR8 *dst, CONST CHAR8 *src)
@@ -52,4 +51,29 @@ strrchra(const CHAR8 *s, INTN c)
 	while (*s++);
 
 	return p;
+}
+
+EFI_STATUS
+PrintGuid (IN EFI_GUID *Guid)
+{
+    if (Guid == NULL) {
+        AsciiPrint ("ERROR: PrintGuid called with a NULL value.\n");
+        return EFI_INVALID_PARAMETER;
+    }
+    
+    AsciiPrint (
+            "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",
+            Guid->Data1,
+            Guid->Data2,
+            Guid->Data3,
+            Guid->Data4[0],
+            Guid->Data4[1],
+            Guid->Data4[2],
+            Guid->Data4[3],
+            Guid->Data4[4],
+            Guid->Data4[5],
+            Guid->Data4[6],
+            Guid->Data4[7]
+            );
+    return EFI_SUCCESS;
 }

--- a/src/path.c
+++ b/src/path.c
@@ -17,9 +17,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
-
 #include "driver.h"
 
 /* copy src into dest converting the path to a relative one inside the current

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -18,9 +18,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <efi.h>
-#include <efilib.h>
-#include <efidebug.h>	/* ASSERT */
+#include "driver.h"
 
 /*
  * Define this if you want to support UTF-16 in UCS-2


### PR DESCRIPTION
* As per http://www.insanelymac.com/forum/topic/300222-updated-efi-filesystem-drivers-efifs-ported-to-edk2/:
  I've decided to port the efifs drivers to EDK2 fully (instead of good old GNU EFI) because I wanted a lot more filesystems supported under UEFI.
  I've now ported them all (all drivers from GRUB).
  This means there is a total of 36 FS drivers (newly) available.
  I've upgraded the routines so they support also BlockIo2 and DIskIo2 protocol from UEFI 2.3.1 if they are available.
  I also extended the SimpleFIleSystem interface to support the extended (OpenEx, ReadEx, WriteEx, FlushEx) functions.
* Note: These changes are NOT officially supported