### PR TITLE
fix possible freeing null pointer and error status return

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -72,8 +72,12 @@ FSGetControllerName2(EFI_COMPONENT_NAME2_PROTOCOL *This,
 
 static VOID
 FreeFsInstance(EFI_FS *Instance) {
-	FreePool(Instance->DevicePathString);
-	FreePool(Instance->RootFile);
+	if(Instance->DevicePathString != NULL)
+		FreePool(Instance->DevicePathString);
+
+	if(Instance->RootFile != NULL)
+		FreePool(Instance->RootFile);
+
 	FreePool(Instance);
 }
 

--- a/src/grub_file.c
+++ b/src/grub_file.c
@@ -164,7 +164,7 @@ grub_disk_read(grub_disk_t disk, grub_disk_addr_t sector,
 
 	if (EFI_ERROR(Status)) {
 		PrintStatusError(Status, L"Could not read block at address %08x", sector);
-		return GRUB_ERR_READ_ERROR;
+		return grub_error (GRUB_ERR_READ_ERROR, N_("Could not read block"));
 	}
 
 	return 0;


### PR DESCRIPTION
If BlockIo not supported by current file system, null pointer will be freed in DriverBindingStart function.

If device_error ocured in disk read, udf driver perform access to null pointer, because grub_udf_read_icb after call grub_disk_read return grub_errno.