### PR TITLE
support SetPosition value 0xFFFFFFFFFFFFFFFF meaning SEEK_END

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -452,6 +452,8 @@ FileWriteEx(IN EFI_FILE_PROTOCOL *This, IN OUT EFI_FILE_IO_TOKEN *Token)
 	return FileWrite(This, &(Token->BufferSize), Token->Buffer);
 }
 
+#define SEEK_END_POSITION 0xFFFFFFFFFFFFFFFF
+
 /**
  * Set file position
  *
@@ -480,7 +482,9 @@ FileSetPosition(EFI_FILE_HANDLE This, UINT64 Position)
 	 * we do not support writes).
 	 */
 	FileSize = GrubGetFileSize(File);
-	if (Position > FileSize) {
+	if (Position == SEEK_END_POSITION) {
+		Position = FileSize;
+	} else if (Position > FileSize) {
 		PrintError(L"'%s': Cannot seek to #%llx of %llx\n",
 				FileName(File), Position, FileSize);
 		return EFI_UNSUPPORTED;


### PR DESCRIPTION
Hi!  

I'd like to propose the following fix:
* As per SetPosition description in UEFI Spec:
    https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf
    Seeking to position 0xFFFFFFFFFFFFFFFF causes the current position to be set to the end of the file.

I understand the motivation for forbidding seeks past the end of the file in read-only drivers, but this value has a special meaning and it is already possible to set the position to the end of file by explicitly specifying its size or reading the entire file.
