### PR TITLE
Change Mtime field to INT64 to adapt to new GRUB changes 

### DIFF
--- a/.vs/grub.vcxproj
+++ b/.vs/grub.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Include="..\grub\grub-core\kern\list.c" />
     <ClCompile Include="..\grub\grub-core\kern\misc.c" />
     <ClCompile Include="..\grub\grub-core\lib\crc.c" />
+    <ClCompile Include="..\grub\grub-core\lib\division.c" />
     <ClCompile Include="..\grub\grub-core\lib\minilzo\minilzo.c" />
     <ClCompile Include="..\grub\grub-core\lib\zstd\entropy_common.c" />
     <ClCompile Include="..\grub\grub-core\lib\zstd\error_private.c" />

--- a/EfiFsPkg/Affs.inf
+++ b/EfiFsPkg/Affs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/affs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Afs.inf
+++ b/EfiFsPkg/Afs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/afs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Bfs.inf
+++ b/EfiFsPkg/Bfs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/bfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Btrfs.inf
+++ b/EfiFsPkg/Btrfs.inf
@@ -41,6 +41,9 @@
   ../grub/grub-core/lib/zstd/zstd_common.c
   ../grub/grub-core/lib/zstd/zstd_decompress.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Cbfs.inf
+++ b/EfiFsPkg/Cbfs.inf
@@ -31,6 +31,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/cbfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Cpio.inf
+++ b/EfiFsPkg/Cpio.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/cpio.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/CpioBe.inf
+++ b/EfiFsPkg/CpioBe.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/cpio_be.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/EroFs.inf
+++ b/EfiFsPkg/EroFs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/erofs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/ExFat.inf
+++ b/EfiFsPkg/ExFat.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/exfat.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Ext2.inf
+++ b/EfiFsPkg/Ext2.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/ext2.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/F2fs.inf
+++ b/EfiFsPkg/F2fs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/f2fs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Fat.inf
+++ b/EfiFsPkg/Fat.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/fat.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Hfs.inf
+++ b/EfiFsPkg/Hfs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/hfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/HfsPlus.inf
+++ b/EfiFsPkg/HfsPlus.inf
@@ -31,6 +31,9 @@
   ../grub/grub-core/fs/hfsplus.c
   ../grub/grub-core/fs/hfspluscomp.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Iso9660.inf
+++ b/EfiFsPkg/Iso9660.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/iso9660.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Jfs.inf
+++ b/EfiFsPkg/Jfs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/jfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Minix.inf
+++ b/EfiFsPkg/Minix.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Minix2.inf
+++ b/EfiFsPkg/Minix2.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix2.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Minix2Be.inf
+++ b/EfiFsPkg/Minix2Be.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix2_be.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Minix3.inf
+++ b/EfiFsPkg/Minix3.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix3.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Minix3Be.inf
+++ b/EfiFsPkg/Minix3Be.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix3_be.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/MinixBe.inf
+++ b/EfiFsPkg/MinixBe.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/minix_be.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/NewC.inf
+++ b/EfiFsPkg/NewC.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/newc.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/NilFs2.inf
+++ b/EfiFsPkg/NilFs2.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/nilfs2.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Ntfs.inf
+++ b/EfiFsPkg/Ntfs.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/ntfs.c
   ../grub/grub-core/fs/ntfscomp.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Odc.inf
+++ b/EfiFsPkg/Odc.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/odc.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/ProcFs.inf
+++ b/EfiFsPkg/ProcFs.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/proc.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/ReiserFs.inf
+++ b/EfiFsPkg/ReiserFs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/reiserfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/RomFs.inf
+++ b/EfiFsPkg/RomFs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/romfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Sfs.inf
+++ b/EfiFsPkg/Sfs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/sfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/SquashFs.inf
+++ b/EfiFsPkg/SquashFs.inf
@@ -39,6 +39,9 @@
   ../grub/grub-core/fs/squash4.c
   ../grub/grub-core/lib/posix_wrap/string.h
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Tar.inf
+++ b/EfiFsPkg/Tar.inf
@@ -30,6 +30,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/tar.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Udf.inf
+++ b/EfiFsPkg/Udf.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/udf.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Ufs.inf
+++ b/EfiFsPkg/Ufs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/ufs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Ufs2.inf
+++ b/EfiFsPkg/Ufs2.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/ufs2.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/UfsBe.inf
+++ b/EfiFsPkg/UfsBe.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/ufs_be.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Xfs.inf
+++ b/EfiFsPkg/Xfs.inf
@@ -29,6 +29,9 @@
   ../grub/grub-core/fs/fshelp.c
   ../grub/grub-core/fs/xfs.c
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/EfiFsPkg/Zfs.inf
+++ b/EfiFsPkg/Zfs.inf
@@ -43,6 +43,9 @@
   ../grub/grub-core/lib/zstd/zstd_decompress.c
   
 
+[Sources.IA32]
+  ../grub/grub-core/lib/division.c
+
 [Packages]
   EfiFsPkg/EfiFsPkg.dec
   MdePkg/MdePkg.dec

--- a/Make.common
+++ b/Make.common
@@ -161,7 +161,8 @@ ifdef DRIVERNAME
   LIBS         += -lgrub -lefi
 
   OBJS          = utf8.o path.o missing.o logging.o grub_file.o this.o file.o driver.o \
-                  $(GRUB_DIR)/grub-core/fs/fshelp.o $(GRUB_DIR)/grub-core/$(FSDIR)/$(DRIVERNAME).o
+                  $(GRUB_DIR)/grub-core/fs/fshelp.o $(GRUB_DIR)/grub-core/$(FSDIR)/$(DRIVERNAME).o \
+                  $(GRUB_DIR)/grub-core/lib/division.o
   DRIVER        = $(DRIVERNAME)_$(ARCH)
 endif
 ifdef EXTRAOBJS
@@ -221,4 +222,5 @@ clean.common:
 
 clean.driver:
 	rm -f $(GRUB_DIR)/grub-core/fs/*.o $(GRUB_DIR)/grub-core/fs/*.d $(GRUB_DIR)/grub-core/io/*.o $(GRUB_DIR)/grub-core/io/*.d \
+  $(GRUB_DIR)/grub-core/lib/*.o \
 	$(GRUB_DIR)/grub-core/fs/zfs/*.o $(GRUB_DIR)/grub-core/fs/zfs/*.d $(SRC_DIR)/*.o $(SRC_DIR)/*.d $(SRC_DIR)/*.so $(SRC_DIR)/*.efi

--- a/src/driver.h
+++ b/src/driver.h
@@ -161,7 +161,7 @@ typedef struct _EFI_GRUB_FILE {
 	EFI_FILE               EfiFile;
 	BOOLEAN                IsDir;
 	INT64                  DirIndex;
-	INT32                  Mtime;
+	INT64                  Mtime;
 	CHAR8                 *path;
 	CHAR8                 *basename;
 	INTN                   RefCount;
@@ -191,7 +191,7 @@ typedef struct _GRUB_DIRHOOK_INFO {
 	UINT32                 MtimeSet:1;
 	UINT32                 CaseInsensitive:1;
 	UINT32                 InodeSet:1;
-	INT32                  Mtime;
+	INT64                  Mtime;
 	UINT64                 Inode;
 } GRUB_DIRHOOK_INFO;
 
@@ -217,7 +217,7 @@ extern CHAR16 *GrubGetUuid(EFI_FS *This);
 extern BOOLEAN GrubFSProbe(EFI_FS *This);
 extern EFI_STATUS GrubDeviceInit(EFI_FS *This);
 extern EFI_STATUS GrubDeviceExit(EFI_FS *This);
-extern VOID GrubTimeToEfiTime(const INT32 t, EFI_TIME *tp);
+extern VOID GrubTimeToEfiTime(const INT64 t, EFI_TIME *tp);
 extern VOID CopyPathRelative(CHAR8 *dest, CHAR8 *src, INTN len);
 extern EFI_STATUS GrubOpen(EFI_GRUB_FILE *File);
 extern EFI_STATUS GrubDir(EFI_GRUB_FILE *File, const CHAR8 *path,

--- a/src/file.c
+++ b/src/file.c
@@ -298,7 +298,6 @@ DirHook(const CHAR8 *name, const GRUB_DIRHOOK_INFO *DirInfo, VOID *Data)
 		return (INT32) Status;
 	}
 
-	// Oh, and of course GRUB uses a 32 bit signed mtime value (seriously, wtf guys?!?)
 	if (DirInfo->MtimeSet)
 		GrubTimeToEfiTime(DirInfo->Mtime, &Time);
 	CopyMem(&Info->CreateTime, &Time, sizeof(Time));

--- a/src/grub.c
+++ b/src/grub.c
@@ -263,9 +263,9 @@ static const unsigned short int __mon_yday[2][13] = {
 
 /* Compute an EFI_TIME representation of a GRUB's mtime_t */
 VOID
-GrubTimeToEfiTime(const INT32 t, EFI_TIME *tp)
+GrubTimeToEfiTime(const INT64 t, EFI_TIME *tp)
 {
-	INT32 days, rem, y;
+	INT64 days, rem, y;
 	const unsigned short int *ip;
 
 	days = t / SECS_PER_DAY;
@@ -286,7 +286,7 @@ GrubTimeToEfiTime(const INT32 t, EFI_TIME *tp)
 
 	while (days < 0 || days >= (__isleap (y) ? 366 : 365)) {
 		/* Guess a corrected year, assuming 365 days per year. */
-		INT32 yg = y + days / 365 - (days % 365 < 0);
+		CONST INT64 yg = y + days / 365 - (days % 365 < 0);
 
 		/* Adjust DAYS and Y to match the guessed year. */
 		days -= ((yg - y) * 365

--- a/src/grub.c
+++ b/src/grub.c
@@ -240,6 +240,28 @@ GrubErrToEFIStatus(grub_err_t err)
 	}
 }
 
+STATIC inline INT64 DivS64x64(INT64 num, INT64 denom, INT64 *rem)
+{
+#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+	return grub_divmod64s(num, denom, rem);
+#else
+	INT64 quot = num / denom;
+	*rem = num % denom;
+	return quot;
+#endif
+}
+
+STATIC inline INT64 ModS64x64(INT64 num, INT64 denom)
+{
+#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+	grub_int64_t rem;
+	grub_divmod64s(num, denom, &rem);
+	return rem;
+#else
+	return num % denom;
+#endif
+}
+
 /* The following is adapted from glibc's (offtime.c, etc.)
  */
 
@@ -254,11 +276,20 @@ static const unsigned short int __mon_yday[2][13] = {
 /* Nonzero if YEAR is a leap year (every 4 years,
    except every 100th isn't, and every 400th is). */
 #define __isleap(year) \
-	((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
+	(ModS64x64(year, 4) == 0 && (ModS64x64(year, 100) != 0 || ModS64x64(year, 400) == 0))
 
 #define SECS_PER_HOUR         (60 * 60)
 #define SECS_PER_DAY          (SECS_PER_HOUR * 24)
+#if defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+STATIC inline INT64 DIV(INT64 a, INT64 b)
+{
+	INT64 rem;
+	CONST INT64 quot = DivS64x64(a, b, &rem);
+	return quot - (rem < 0);
+}
+#else
 #define DIV(a, b)             ((a) / (b) - ((a) % (b) < 0))
+#endif
 #define LEAPS_THRU_END_OF(y)  (DIV (y, 4) - DIV (y, 100) + DIV (y, 400))
 
 /* Compute an EFI_TIME representation of a GRUB's mtime_t */
@@ -268,8 +299,7 @@ GrubTimeToEfiTime(const INT64 t, EFI_TIME *tp)
 	INT64 days, rem, y;
 	const unsigned short int *ip;
 
-	days = t / SECS_PER_DAY;
-	rem = t % SECS_PER_DAY;
+	days = DivS64x64(t, SECS_PER_DAY, &rem);
 	while (rem < 0) {
 		rem += SECS_PER_DAY;
 		--days;
@@ -278,15 +308,14 @@ GrubTimeToEfiTime(const INT64 t, EFI_TIME *tp)
 		rem -= SECS_PER_DAY;
 		++days;
 	}
-	tp->Hour = (UINT8) (rem / SECS_PER_HOUR);
-	rem %= SECS_PER_HOUR;
-	tp->Minute = (UINT8) (rem / 60);
-	tp->Second = (UINT8) (rem % 60);
+	tp->Hour = (UINT8) DivS64x64(rem, SECS_PER_HOUR, &rem);
+	tp->Minute = (UINT8) DivS64x64(rem, 60, &rem);
+	tp->Second = (UINT8) rem;
 	y = 1970;
 
 	while (days < 0 || days >= (__isleap (y) ? 366 : 365)) {
 		/* Guess a corrected year, assuming 365 days per year. */
-		CONST INT64 yg = y + days / 365 - (days % 365 < 0);
+		CONST INT64 yg = y + DIV(days, 365);
 
 		/* Adjust DAYS and Y to match the guessed year. */
 		days -= ((yg - y) * 365


### PR DESCRIPTION
This pull request changes the Mtime field to INT64 to adapt to the new GRUB changes

* GRUB upstream commit [81f1962393f4403e2b6b127f23524a962a236afb](https://gitlab.freedesktop.org/gnu-grub/grub/-/commit/81f1962393f4403e2b6b127f23524a962a236afb) changed mtime to `grub_int64_t`