### PR TITLE
Fix build with edk2-202602

### DIFF
--- a/EfiFsPkg/Affs.inf
+++ b/EfiFsPkg/Affs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Afs.inf
+++ b/EfiFsPkg/Afs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Bfs.inf
+++ b/EfiFsPkg/Bfs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Btrfs.inf
+++ b/EfiFsPkg/Btrfs.inf
@@ -68,7 +68,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Cbfs.inf
+++ b/EfiFsPkg/Cbfs.inf
@@ -58,7 +58,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Cpio.inf
+++ b/EfiFsPkg/Cpio.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/CpioBe.inf
+++ b/EfiFsPkg/CpioBe.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/EroFs.inf
+++ b/EfiFsPkg/EroFs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/ExFat.inf
+++ b/EfiFsPkg/ExFat.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Ext2.inf
+++ b/EfiFsPkg/Ext2.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/F2fs.inf
+++ b/EfiFsPkg/F2fs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Fat.inf
+++ b/EfiFsPkg/Fat.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Hfs.inf
+++ b/EfiFsPkg/Hfs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/HfsPlus.inf
+++ b/EfiFsPkg/HfsPlus.inf
@@ -58,7 +58,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Iso9660.inf
+++ b/EfiFsPkg/Iso9660.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Jfs.inf
+++ b/EfiFsPkg/Jfs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Minix.inf
+++ b/EfiFsPkg/Minix.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Minix2.inf
+++ b/EfiFsPkg/Minix2.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Minix2Be.inf
+++ b/EfiFsPkg/Minix2Be.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Minix3.inf
+++ b/EfiFsPkg/Minix3.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Minix3Be.inf
+++ b/EfiFsPkg/Minix3Be.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/MinixBe.inf
+++ b/EfiFsPkg/MinixBe.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/NewC.inf
+++ b/EfiFsPkg/NewC.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/NilFs2.inf
+++ b/EfiFsPkg/NilFs2.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Ntfs.inf
+++ b/EfiFsPkg/Ntfs.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Odc.inf
+++ b/EfiFsPkg/Odc.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/ProcFs.inf
+++ b/EfiFsPkg/ProcFs.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/ReiserFs.inf
+++ b/EfiFsPkg/ReiserFs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/RomFs.inf
+++ b/EfiFsPkg/RomFs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Sfs.inf
+++ b/EfiFsPkg/Sfs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/SquashFs.inf
+++ b/EfiFsPkg/SquashFs.inf
@@ -66,7 +66,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Tar.inf
+++ b/EfiFsPkg/Tar.inf
@@ -57,7 +57,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Udf.inf
+++ b/EfiFsPkg/Udf.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Ufs.inf
+++ b/EfiFsPkg/Ufs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Ufs2.inf
+++ b/EfiFsPkg/Ufs2.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/UfsBe.inf
+++ b/EfiFsPkg/UfsBe.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Xfs.inf
+++ b/EfiFsPkg/Xfs.inf
@@ -56,7 +56,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 

--- a/EfiFsPkg/Zfs.inf
+++ b/EfiFsPkg/Zfs.inf
@@ -70,7 +70,6 @@
   gEfiBlockIoProtocolGuid
   gEfiBlockIo2ProtocolGuid
   gEfiSimpleFileSystemProtocolGuid
-  gEfiUnicodeCollationProtocolGuid
   gEfiUnicodeCollation2ProtocolGuid
   gEfiDevicePathToTextProtocolGuid
 


### PR DESCRIPTION
The latest edk2 release removed support for `gEfiUnicodeCollationProtocolGuid`. Remove it to fix the build. See https://github.com/tianocore/edk2/pull/11380 and https://github.com/tianocore/edk2-platforms/pull/864 for more details.
```bash
       Last 25 log lines:
       > build.py...
       > /build/edk2-202602-unvendored-src/EfiFsPkg/EfiFsPkg/EroFs.inf(59): error 4000: Value of Protocol [gEfiUnicodeCollationProtocolGuid] is not found under [Protocols] section in
       >  /build/edk2-202602-unvendored-src/EfiFsPkg/EfiFsPkg.dec
       >         /build/edk2-202602-unvendored-src/MdePkg/MdePkg.dec
       >     /build/edk2-202602-unvendored-src/ShellPkg/ShellPkg.dec

```